### PR TITLE
Add clean architecture scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,5 @@
-# folloapp
+# FolloApp
 
-A new Flutter project.
+FolloApp helps job seekers track applications, interviews and follow‑ups. The project is organized using **Clean Architecture** with BLoC state management.
 
-## Getting Started
-
-This project is a starting point for a Flutter application.
-
-A few resources to get you started if this is your first Flutter project:
-
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
-
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
-# folloapp
+See [docs/architecture.md](docs/architecture.md) for the full design including folder structure, data flow diagram and security considerations.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,76 @@
+# FolloApp Architecture
+
+This document describes the high level structure of the project following **Clean Architecture** and **SOLID** principles.
+
+## Folder Structure
+```
+lib/
+├── core/                 # common utilities and base classes
+│   ├── error/
+│   ├── usecases/
+│   └── utils/
+├── features/
+│   ├── authentication/
+│   │   ├── data/
+│   │   │   ├── datasources/
+│   │   │   ├── models/
+│   │   │   └── repositories/
+│   │   ├── domain/
+│   │   │   ├── entities/
+│   │   │   ├── repositories/
+│   │   │   └── usecases/
+│   │   └── presentation/
+│   │       ├── bloc/
+│   │       ├── pages/
+│   │       └── widgets/
+│   ├── job_tracker/       # job application CRUD
+│   │   ├── data/
+│   │   ├── domain/
+│   │   └── presentation/
+│   ├── dashboard/
+│   │   ├── data/
+│   │   ├── domain/
+│   │   └── presentation/
+│   ├── calendar/
+│   │   └── ...
+│   ├── notifications/
+│   │   └── ...
+│   └── analytics/
+│       └── ...
+└── main.dart
+```
+Each feature contains `data`, `domain` and `presentation` layers. The **domain** layer defines entities, repositories (abstract interfaces) and use cases. The **data** layer contains concrete implementations such as Hive datasources, Gmail API adapters, etc. The **presentation** layer uses BLoC for state management.
+
+## Data Flow Diagram
+```
+UI Widgets
+    │
+    ▼ (events)
+Bloc  <-----------------------
+    │           ▲ use cases
+    ▼ states    │
+UseCase -------> Repository (abstract)
+                 │  ▲ implements
+                 ▼  │
+          DataSource/Services
+```
+The UI dispatches events to BLoC. BLoC calls use cases from the domain layer. Use cases depend on abstract repositories, which are implemented in the data layer using local storage (Hive/Sqflite) or remote services (Gmail API). BLoC emits states back to the UI.
+
+## Security Considerations
+- **Encrypted Storage**: Hive is configured with an AES encryption key stored in `flutter_secure_storage` to protect PIN codes, Gmail tokens and job data.
+- **Authentication**: Login requires a 4‑digit PIN and optionally biometric verification using `local_auth` for FaceID/TouchID.
+- **Gmail Integration**: OAuth2 flow via `google_sign_in`/`googleapis` is used. Access tokens are securely stored and refreshed locally.
+- **Data Privacy**: No job data leaves the device except when interacting with Gmail APIs. Network requests use HTTPS.
+
+## State Management
+All features expose BLoC classes inside `presentation/bloc`. BLoC handles events and yields states to the UI. Repositories and use cases are injected to keep layers decoupled and easily testable.
+
+## Initial Dependencies
+Dependencies defined in `pubspec.yaml` include:
+- `flutter_bloc` + `equatable` for BLoC state management
+- `hive` + `hive_flutter` + `flutter_secure_storage` for encrypted local persistence
+- `local_auth` for biometrics
+- `google_sign_in`, `googleapis`, `http` for Gmail integration
+- `flutter_local_notifications` for reminders
+- `table_calendar` and `fl_chart` for calendar and analytics views
+- `animations` for Material 3 animated transitions

--- a/lib/core/error/failure.dart
+++ b/lib/core/error/failure.dart
@@ -1,0 +1,4 @@
+abstract class Failure {
+  final String message;
+  const Failure(this.message);
+}

--- a/lib/core/usecases/usecase.dart
+++ b/lib/core/usecases/usecase.dart
@@ -1,0 +1,5 @@
+abstract class UseCase<Type, Params> {
+  Future<Type> call(Params params);
+}
+
+class NoParams {}

--- a/lib/core/utils/constants.dart
+++ b/lib/core/utils/constants.dart
@@ -1,0 +1,9 @@
+class HiveBoxes {
+  static const applications = 'applications_box';
+  static const settings = 'settings_box';
+}
+
+class Routes {
+  static const dashboard = '/';
+  static const login = '/login';
+}

--- a/lib/features/analytics/domain/entities/analytics_data.dart
+++ b/lib/features/analytics/domain/entities/analytics_data.dart
@@ -1,0 +1,13 @@
+class AnalyticsData {
+  final int applied;
+  final int interviews;
+  final int offers;
+  final int rejections;
+
+  const AnalyticsData({
+    required this.applied,
+    required this.interviews,
+    required this.offers,
+    required this.rejections,
+  });
+}

--- a/lib/features/analytics/domain/repositories/analytics_repository.dart
+++ b/lib/features/analytics/domain/repositories/analytics_repository.dart
@@ -1,0 +1,7 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/failure.dart';
+import '../entities/analytics_data.dart';
+
+abstract class AnalyticsRepository {
+  Future<Either<Failure, AnalyticsData>> fetchAnalytics();
+}

--- a/lib/features/analytics/domain/usecases/get_analytics.dart
+++ b/lib/features/analytics/domain/usecases/get_analytics.dart
@@ -1,0 +1,15 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/failure.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/analytics_data.dart';
+import '../repositories/analytics_repository.dart';
+
+class GetAnalytics implements UseCase<AnalyticsData, NoParams> {
+  final AnalyticsRepository repository;
+  GetAnalytics(this.repository);
+
+  @override
+  Future<Either<Failure, AnalyticsData>> call(NoParams params) {
+    return repository.fetchAnalytics();
+  }
+}

--- a/lib/features/analytics/presentation/bloc/analytics_bloc.dart
+++ b/lib/features/analytics/presentation/bloc/analytics_bloc.dart
@@ -1,0 +1,24 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import '../../domain/entities/analytics_data.dart';
+import '../../domain/usecases/get_analytics.dart';
+import '../../../../core/usecases/usecase.dart';
+
+part 'analytics_event.dart';
+part 'analytics_state.dart';
+
+class AnalyticsBloc extends Bloc<AnalyticsEvent, AnalyticsState> {
+  final GetAnalytics getAnalytics;
+  AnalyticsBloc({required this.getAnalytics}) : super(AnalyticsInitial()) {
+    on<LoadAnalytics>(_onLoad);
+  }
+
+  Future<void> _onLoad(LoadAnalytics event, Emitter<AnalyticsState> emit) async {
+    emit(AnalyticsLoading());
+    final result = await getAnalytics(NoParams());
+    result.fold(
+      (failure) => emit(AnalyticsFailure(failure.message)),
+      (data) => emit(AnalyticsLoaded(data)),
+    );
+  }
+}

--- a/lib/features/analytics/presentation/bloc/analytics_event.dart
+++ b/lib/features/analytics/presentation/bloc/analytics_event.dart
@@ -1,0 +1,10 @@
+part of 'analytics_bloc.dart';
+
+abstract class AnalyticsEvent extends Equatable {
+  const AnalyticsEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadAnalytics extends AnalyticsEvent {}

--- a/lib/features/analytics/presentation/bloc/analytics_state.dart
+++ b/lib/features/analytics/presentation/bloc/analytics_state.dart
@@ -1,0 +1,28 @@
+part of 'analytics_bloc.dart';
+
+abstract class AnalyticsState extends Equatable {
+  const AnalyticsState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AnalyticsInitial extends AnalyticsState {}
+
+class AnalyticsLoading extends AnalyticsState {}
+
+class AnalyticsLoaded extends AnalyticsState {
+  final AnalyticsData data;
+  const AnalyticsLoaded(this.data);
+
+  @override
+  List<Object?> get props => [data];
+}
+
+class AnalyticsFailure extends AnalyticsState {
+  final String message;
+  const AnalyticsFailure(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/authentication/domain/entities/user.dart
+++ b/lib/features/authentication/domain/entities/user.dart
@@ -1,0 +1,5 @@
+class User {
+  final String id;
+  final String email;
+  const User({required this.id, required this.email});
+}

--- a/lib/features/authentication/domain/repositories/auth_repository.dart
+++ b/lib/features/authentication/domain/repositories/auth_repository.dart
@@ -1,0 +1,9 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/failure.dart';
+import '../entities/user.dart';
+
+abstract class AuthRepository {
+  Future<Either<Failure, User>> authenticateWithPin(String pin);
+  Future<Either<Failure, User>> authenticateBiometric();
+  Future<void> logout();
+}

--- a/lib/features/authentication/domain/usecases/login_with_pin.dart
+++ b/lib/features/authentication/domain/usecases/login_with_pin.dart
@@ -1,0 +1,15 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/failure.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/user.dart';
+import '../repositories/auth_repository.dart';
+
+class LoginWithPin implements UseCase<User, String> {
+  final AuthRepository repository;
+  LoginWithPin(this.repository);
+
+  @override
+  Future<Either<Failure, User>> call(String pin) {
+    return repository.authenticateWithPin(pin);
+  }
+}

--- a/lib/features/authentication/presentation/bloc/auth_bloc.dart
+++ b/lib/features/authentication/presentation/bloc/auth_bloc.dart
@@ -1,0 +1,24 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../domain/entities/user.dart';
+import '../../domain/usecases/login_with_pin.dart';
+
+part 'auth_event.dart';
+part 'auth_state.dart';
+
+class AuthBloc extends Bloc<AuthEvent, AuthState> {
+  final LoginWithPin loginWithPin;
+  AuthBloc({required this.loginWithPin}) : super(AuthInitial()) {
+    on<PinSubmitted>(_onPinSubmitted);
+  }
+
+  Future<void> _onPinSubmitted(PinSubmitted event, Emitter<AuthState> emit) async {
+    emit(AuthLoading());
+    final result = await loginWithPin(event.pin);
+    result.fold(
+      (failure) => emit(AuthFailure(failure.message)),
+      (user) => emit(AuthSuccess(user)),
+    );
+  }
+}

--- a/lib/features/authentication/presentation/bloc/auth_event.dart
+++ b/lib/features/authentication/presentation/bloc/auth_event.dart
@@ -1,0 +1,16 @@
+part of 'auth_bloc.dart';
+
+abstract class AuthEvent extends Equatable {
+  const AuthEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class PinSubmitted extends AuthEvent {
+  final String pin;
+  const PinSubmitted(this.pin);
+
+  @override
+  List<Object?> get props => [pin];
+}

--- a/lib/features/authentication/presentation/bloc/auth_state.dart
+++ b/lib/features/authentication/presentation/bloc/auth_state.dart
@@ -1,0 +1,28 @@
+part of 'auth_bloc.dart';
+
+abstract class AuthState extends Equatable {
+  const AuthState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AuthInitial extends AuthState {}
+
+class AuthLoading extends AuthState {}
+
+class AuthSuccess extends AuthState {
+  final User user;
+  const AuthSuccess(this.user);
+
+  @override
+  List<Object?> get props => [user];
+}
+
+class AuthFailure extends AuthState {
+  final String message;
+  const AuthFailure(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/calendar/domain/entities/calendar_event.dart
+++ b/lib/features/calendar/domain/entities/calendar_event.dart
@@ -1,0 +1,7 @@
+class CalendarEvent {
+  final String id;
+  final String title;
+  final DateTime eventDate;
+
+  const CalendarEvent({required this.id, required this.title, required this.eventDate});
+}

--- a/lib/features/calendar/domain/repositories/calendar_repository.dart
+++ b/lib/features/calendar/domain/repositories/calendar_repository.dart
@@ -1,0 +1,7 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/failure.dart';
+import '../entities/calendar_event.dart';
+
+abstract class CalendarRepository {
+  Future<Either<Failure, void>> addCalendarEvent(CalendarEvent event);
+}

--- a/lib/features/calendar/domain/usecases/add_calendar_event.dart
+++ b/lib/features/calendar/domain/usecases/add_calendar_event.dart
@@ -1,0 +1,15 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/failure.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/calendar_event.dart';
+import '../repositories/calendar_repository.dart';
+
+class AddCalendarEvent implements UseCase<void, CalendarEvent> {
+  final CalendarRepository repository;
+  AddCalendarEvent(this.repository);
+
+  @override
+  Future<Either<Failure, void>> call(CalendarEvent event) {
+    return repository.addCalendarEvent(event);
+  }
+}

--- a/lib/features/calendar/presentation/bloc/calendar_bloc.dart
+++ b/lib/features/calendar/presentation/bloc/calendar_bloc.dart
@@ -1,0 +1,23 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import '../../domain/usecases/add_calendar_event.dart';
+import '../../domain/entities/calendar_event.dart';
+
+part 'calendar_event.dart';
+part 'calendar_state.dart';
+
+class CalendarBloc extends Bloc<CalendarBlocEvent, CalendarBlocState> {
+  final AddCalendarEvent addCalendarEvent;
+  CalendarBloc({required this.addCalendarEvent}) : super(CalendarInitial()) {
+    on<ScheduleCalendar>(_onSchedule);
+  }
+
+  Future<void> _onSchedule(ScheduleCalendar event, Emitter<CalendarBlocState> emit) async {
+    emit(CalendarLoading());
+    final result = await addCalendarEvent(event.event);
+    result.fold(
+      (failure) => emit(CalendarFailure(failure.message)),
+      (_) => emit(CalendarScheduled()),
+    );
+  }
+}

--- a/lib/features/calendar/presentation/bloc/calendar_event.dart
+++ b/lib/features/calendar/presentation/bloc/calendar_event.dart
@@ -1,0 +1,16 @@
+part of 'calendar_bloc.dart';
+
+abstract class CalendarBlocEvent extends Equatable {
+  const CalendarBlocEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class ScheduleCalendar extends CalendarBlocEvent {
+  final CalendarEvent event;
+  const ScheduleCalendar(this.event);
+
+  @override
+  List<Object?> get props => [event];
+}

--- a/lib/features/calendar/presentation/bloc/calendar_state.dart
+++ b/lib/features/calendar/presentation/bloc/calendar_state.dart
@@ -1,0 +1,22 @@
+part of 'calendar_bloc.dart';
+
+abstract class CalendarBlocState extends Equatable {
+  const CalendarBlocState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class CalendarInitial extends CalendarBlocState {}
+
+class CalendarLoading extends CalendarBlocState {}
+
+class CalendarScheduled extends CalendarBlocState {}
+
+class CalendarFailure extends CalendarBlocState {
+  final String message;
+  const CalendarFailure(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/dashboard/domain/entities/dashboard_data.dart
+++ b/lib/features/dashboard/domain/entities/dashboard_data.dart
@@ -1,0 +1,6 @@
+import '../../job_tracker/domain/entities/job_application.dart';
+
+class DashboardData {
+  final List<JobApplication> applications;
+  const DashboardData({required this.applications});
+}

--- a/lib/features/dashboard/domain/repositories/dashboard_repository.dart
+++ b/lib/features/dashboard/domain/repositories/dashboard_repository.dart
@@ -1,0 +1,7 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/failure.dart';
+import '../entities/dashboard_data.dart';
+
+abstract class DashboardRepository {
+  Future<Either<Failure, DashboardData>> fetchDashboardData();
+}

--- a/lib/features/dashboard/domain/usecases/get_dashboard_data.dart
+++ b/lib/features/dashboard/domain/usecases/get_dashboard_data.dart
@@ -1,0 +1,13 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/failure.dart';
+import '../entities/dashboard_data.dart';
+import '../repositories/dashboard_repository.dart';
+
+class GetDashboardData {
+  final DashboardRepository repository;
+  GetDashboardData(this.repository);
+
+  Future<Either<Failure, DashboardData>> call() {
+    return repository.fetchDashboardData();
+  }
+}

--- a/lib/features/dashboard/presentation/bloc/dashboard_bloc.dart
+++ b/lib/features/dashboard/presentation/bloc/dashboard_bloc.dart
@@ -1,0 +1,22 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import '../../domain/usecases/get_dashboard_data.dart';
+
+part 'dashboard_event.dart';
+part 'dashboard_state.dart';
+
+class DashboardBloc extends Bloc<DashboardEvent, DashboardState> {
+  final GetDashboardData getDashboardData;
+  DashboardBloc({required this.getDashboardData}) : super(DashboardInitial()) {
+    on<LoadDashboard>(_onLoad);
+  }
+
+  Future<void> _onLoad(LoadDashboard event, Emitter<DashboardState> emit) async {
+    emit(DashboardLoading());
+    final result = await getDashboardData();
+    result.fold(
+      (failure) => emit(DashboardFailure(failure.message)),
+      (data) => emit(DashboardLoaded(data)),
+    );
+  }
+}

--- a/lib/features/dashboard/presentation/bloc/dashboard_event.dart
+++ b/lib/features/dashboard/presentation/bloc/dashboard_event.dart
@@ -1,0 +1,10 @@
+part of 'dashboard_bloc.dart';
+
+abstract class DashboardEvent extends Equatable {
+  const DashboardEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadDashboard extends DashboardEvent {}

--- a/lib/features/dashboard/presentation/bloc/dashboard_state.dart
+++ b/lib/features/dashboard/presentation/bloc/dashboard_state.dart
@@ -1,0 +1,28 @@
+part of 'dashboard_bloc.dart';
+
+abstract class DashboardState extends Equatable {
+  const DashboardState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class DashboardInitial extends DashboardState {}
+
+class DashboardLoading extends DashboardState {}
+
+class DashboardLoaded extends DashboardState {
+  final DashboardData data;
+  const DashboardLoaded(this.data);
+
+  @override
+  List<Object?> get props => [data];
+}
+
+class DashboardFailure extends DashboardState {
+  final String message;
+  const DashboardFailure(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/dashboard/presentation/pages/dashboard_page.dart
+++ b/lib/features/dashboard/presentation/pages/dashboard_page.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import '../../bloc/dashboard_bloc.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class DashboardPage extends StatelessWidget {
+  const DashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dashboard')),
+      body: BlocBuilder<DashboardBloc, DashboardState>(
+        builder: (context, state) {
+          // Placeholder UI
+          return const Center(child: Text('Dashboard'));
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/job_tracker/domain/entities/job_application.dart
+++ b/lib/features/job_tracker/domain/entities/job_application.dart
@@ -1,0 +1,17 @@
+class JobApplication {
+  final String id;
+  final String company;
+  final String position;
+  final DateTime appliedOn;
+  final JobStatus status;
+
+  JobApplication({
+    required this.id,
+    required this.company,
+    required this.position,
+    required this.appliedOn,
+    this.status = JobStatus.applied,
+  });
+}
+
+enum JobStatus { applied, interview, offer, rejected }

--- a/lib/features/job_tracker/domain/repositories/job_repository.dart
+++ b/lib/features/job_tracker/domain/repositories/job_repository.dart
@@ -1,0 +1,9 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/failure.dart';
+import '../entities/job_application.dart';
+
+abstract class JobRepository {
+  Future<Either<Failure, List<JobApplication>>> fetchApplications();
+  Future<Either<Failure, void>> addApplication(JobApplication application);
+  Future<Either<Failure, void>> updateApplication(JobApplication application);
+}

--- a/lib/features/job_tracker/domain/usecases/get_applications.dart
+++ b/lib/features/job_tracker/domain/usecases/get_applications.dart
@@ -1,0 +1,15 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/failure.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/job_application.dart';
+import '../repositories/job_repository.dart';
+
+class GetApplications implements UseCase<List<JobApplication>, NoParams> {
+  final JobRepository repository;
+  GetApplications(this.repository);
+
+  @override
+  Future<Either<Failure, List<JobApplication>>> call(NoParams params) {
+    return repository.fetchApplications();
+  }
+}

--- a/lib/features/job_tracker/presentation/bloc/job_bloc.dart
+++ b/lib/features/job_tracker/presentation/bloc/job_bloc.dart
@@ -1,0 +1,24 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import '../../domain/entities/job_application.dart';
+import '../../domain/usecases/get_applications.dart';
+import '../../../../core/usecases/usecase.dart';
+
+part 'job_event.dart';
+part 'job_state.dart';
+
+class JobBloc extends Bloc<JobEvent, JobState> {
+  final GetApplications getApplications;
+  JobBloc({required this.getApplications}) : super(JobInitial()) {
+    on<LoadJobs>(_onLoadJobs);
+  }
+
+  Future<void> _onLoadJobs(LoadJobs event, Emitter<JobState> emit) async {
+    emit(JobLoading());
+    final result = await getApplications(NoParams());
+    result.fold(
+      (failure) => emit(JobFailure(failure.message)),
+      (jobs) => emit(JobLoaded(jobs)),
+    );
+  }
+}

--- a/lib/features/job_tracker/presentation/bloc/job_event.dart
+++ b/lib/features/job_tracker/presentation/bloc/job_event.dart
@@ -1,0 +1,10 @@
+part of 'job_bloc.dart';
+
+abstract class JobEvent extends Equatable {
+  const JobEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadJobs extends JobEvent {}

--- a/lib/features/job_tracker/presentation/bloc/job_state.dart
+++ b/lib/features/job_tracker/presentation/bloc/job_state.dart
@@ -1,0 +1,28 @@
+part of 'job_bloc.dart';
+
+abstract class JobState extends Equatable {
+  const JobState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class JobInitial extends JobState {}
+
+class JobLoading extends JobState {}
+
+class JobLoaded extends JobState {
+  final List<JobApplication> jobs;
+  const JobLoaded(this.jobs);
+
+  @override
+  List<Object?> get props => [jobs];
+}
+
+class JobFailure extends JobState {
+  final String message;
+  const JobFailure(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/notifications/domain/entities/notification_item.dart
+++ b/lib/features/notifications/domain/entities/notification_item.dart
@@ -1,0 +1,7 @@
+class NotificationItem {
+  final String id;
+  final String title;
+  final DateTime scheduledAt;
+
+  const NotificationItem({required this.id, required this.title, required this.scheduledAt});
+}

--- a/lib/features/notifications/domain/repositories/notification_repository.dart
+++ b/lib/features/notifications/domain/repositories/notification_repository.dart
@@ -1,0 +1,7 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/failure.dart';
+import '../entities/notification_item.dart';
+
+abstract class NotificationRepository {
+  Future<Either<Failure, void>> scheduleNotification(NotificationItem item);
+}

--- a/lib/features/notifications/domain/usecases/schedule_notification.dart
+++ b/lib/features/notifications/domain/usecases/schedule_notification.dart
@@ -1,0 +1,15 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/failure.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/notification_item.dart';
+import '../repositories/notification_repository.dart';
+
+class ScheduleNotification implements UseCase<void, NotificationItem> {
+  final NotificationRepository repository;
+  ScheduleNotification(this.repository);
+
+  @override
+  Future<Either<Failure, void>> call(NotificationItem item) {
+    return repository.scheduleNotification(item);
+  }
+}

--- a/lib/features/notifications/presentation/bloc/notification_bloc.dart
+++ b/lib/features/notifications/presentation/bloc/notification_bloc.dart
@@ -1,0 +1,23 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import '../../domain/usecases/schedule_notification.dart';
+import '../../domain/entities/notification_item.dart';
+
+part 'notification_event.dart';
+part 'notification_state.dart';
+
+class NotificationBloc extends Bloc<NotificationEvent, NotificationState> {
+  final ScheduleNotification scheduleNotification;
+  NotificationBloc({required this.scheduleNotification}) : super(NotificationInitial()) {
+    on<AddNotification>(_onAdd);
+  }
+
+  Future<void> _onAdd(AddNotification event, Emitter<NotificationState> emit) async {
+    emit(NotificationLoading());
+    final result = await scheduleNotification(event.item);
+    result.fold(
+      (failure) => emit(NotificationFailure(failure.message)),
+      (_) => emit(NotificationScheduled()),
+    );
+  }
+}

--- a/lib/features/notifications/presentation/bloc/notification_event.dart
+++ b/lib/features/notifications/presentation/bloc/notification_event.dart
@@ -1,0 +1,16 @@
+part of 'notification_bloc.dart';
+
+abstract class NotificationEvent extends Equatable {
+  const NotificationEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AddNotification extends NotificationEvent {
+  final NotificationItem item;
+  const AddNotification(this.item);
+
+  @override
+  List<Object?> get props => [item];
+}

--- a/lib/features/notifications/presentation/bloc/notification_state.dart
+++ b/lib/features/notifications/presentation/bloc/notification_state.dart
@@ -1,0 +1,22 @@
+part of 'notification_bloc.dart';
+
+abstract class NotificationState extends Equatable {
+  const NotificationState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class NotificationInitial extends NotificationState {}
+
+class NotificationLoading extends NotificationState {}
+
+class NotificationScheduled extends NotificationState {}
+
+class NotificationFailure extends NotificationState {
+  final String message;
+  const NotificationFailure(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,122 +1,30 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'core/utils/constants.dart';
+import 'features/dashboard/presentation/bloc/dashboard_bloc.dart';
+import 'features/dashboard/presentation/pages/dashboard_page.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(const FolloApp());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  // This widget is the root of your application.
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      // This call to setState tells the Flutter framework that something has
-      // changed in this State, which causes it to rerun the build method below
-      // so that the display can reflect the updated values. If we changed
-      // _counter without calling setState(), then the build method would not be
-      // called again, and so nothing would appear to happen.
-      _counter++;
-    });
-  }
+class FolloApp extends StatelessWidget {
+  const FolloApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
-    return Scaffold(
-      appBar: AppBar(
-        // TRY THIS: Try changing the color here to a specific color (to
-        // Colors.amber, perhaps?) and trigger a hot reload to see the AppBar
-        // change color while the other colors stay the same.
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        // Here we take the value from the MyHomePage object that was created by
-        // the App.build method, and use it to set our appbar title.
-        title: Text(widget.title),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider(create: (_) => DashboardBloc(getDashboardData: () => throw UnimplementedError())),
+      ],
+      child: MaterialApp(
+        title: 'FolloApp',
+        theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.indigo),
+        routes: {
+          Routes.dashboard: (_) => const DashboardPage(),
+        },
+        initialRoute: Routes.dashboard,
       ),
-      body: Center(
-        // Center is a layout widget. It takes a single child and positions it
-        // in the middle of the parent.
-        child: Column(
-          // Column is also a layout widget. It takes a list of children and
-          // arranges them vertically. By default, it sizes itself to fit its
-          // children horizontally, and tries to be as tall as its parent.
-          //
-          // Column has various properties to control how it sizes itself and
-          // how it positions its children. Here we use mainAxisAlignment to
-          // center the children vertically; the main axis here is the vertical
-          // axis because Columns are vertical (the cross axis would be
-          // horizontal).
-          //
-          // TRY THIS: Invoke "debug painting" (choose the "Toggle Debug Paint"
-          // action in the IDE, or press "p" in the console), to see the
-          // wireframe for each widget.
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text('You have pushed the button this many times:'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,20 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
 
+  flutter_bloc: ^8.1.4
+  equatable: ^2.0.5
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
+  path_provider: ^2.1.2
+  flutter_secure_storage: ^9.0.0
+  local_auth: ^2.1.7
+  google_sign_in: ^6.2.1
+  googleapis: ^13.1.0
+  http: ^1.2.1
+  flutter_local_notifications: ^16.1.0
+  table_calendar: ^3.0.9
+  fl_chart: ^0.66.0
+  animations: ^2.0.11
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- set up Clean Architecture folder structure with core and feature layers
- add BLoC classes and entities for major features
- create architecture documentation with data flow and security notes
- update Material 3 app entry point
- list initial dependencies

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885418c2f3c832f962f952604cd5dc7